### PR TITLE
Add support for callouts, add to empty pages

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -7,3 +7,29 @@
 .search-input {
   color: $body-text-color
 };
+
+$callouts: (
+    notice: ($blue-300, rgba($blue-000, .2), 'NOTICE'),
+    warning: ($yellow-300, rgba($yellow-000, .2), 'WARNING'),
+    danger: ($red-300, rgba($red-000, .2), 'DANGER')
+);
+
+@each $class, $props in $callouts {
+    .#{$class} {
+        background: nth($props, 2);
+        border-left: $border-radius solid nth($props, 1);
+        border-radius: $border-radius;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
+        padding: .8rem;
+
+        &::before {
+            color: nth($props, 1);
+            content: nth($props, 3);
+            display: block;
+            font-weight: bold;
+            font-size: .75em;
+            padding-bottom: .125rem;
+        }
+    }
+}
+

--- a/guides/alignment.md
+++ b/guides/alignment.md
@@ -6,3 +6,6 @@ nav_order: 8
 ---
 
 # Burr Alignment
+
+{: .notice }
+This page is under development

--- a/guides/maintenance.md
+++ b/guides/maintenance.md
@@ -6,3 +6,5 @@ nav_order: 6
 ---
 
 # Machine Maintenance
+
+{: .notice } This page is under development

--- a/info/bripe.md
+++ b/info/bripe.md
@@ -6,3 +6,5 @@ nav_order: 3
 ---
 
 # Living the Bripe Life
+
+{: .notice } This page is under development

--- a/info/levers.md
+++ b/info/levers.md
@@ -6,3 +6,5 @@ nav_order: 2
 ---
 
 # Lever Espresso Machines
+
+{: .notice } This page is under development

--- a/manufacturers/baratza/baratza.md
+++ b/manufacturers/baratza/baratza.md
@@ -6,3 +6,5 @@ has_children: true
 ---
 
 # Baratza
+
+{: .notice } This page is under development

--- a/manufacturers/breville/slayermod.md
+++ b/manufacturers/breville/slayermod.md
@@ -6,3 +6,5 @@ grand_parent: Manufacturers
 ---
 
 # Slayer Mod
+
+{: .notice } This page is under development

--- a/recommendations/midrange-machines.md
+++ b/recommendations/midrange-machines.md
@@ -6,3 +6,5 @@ nav_order: 3
 ---
 
 # Midrange Espresso Machines
+
+{: .notice } This page is under development


### PR DESCRIPTION
This PR should add support for three basic callouts - for an example on how they will look, see https://pdmosses.github.io/just-the-docs-tests/docs/css/admonitions.html#using-ials-in-kramdown-with-custom-styles

My implementation is a little different - for a blue Notice, use {: .notice} in front of a paragraph
For a orange/yellow Warning, use {: .warning}
For a red Danger, use {: .danger}

If anyone wants help using them, ask me in #resource-development on EAF (@Agatheus#1032)

I'll add usage info later :)