### PR TITLE
Add Mermaid.js support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,6 @@ aux_links_new_tab: true
 remote_theme: pmarsceill/just-the-docs
 color_scheme: "light"
 
-footer_content: "Copyright &copy; Espresso Aficionados"
-
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true #
 gh_edit_link_text: "Edit this page on GitHub"

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,0 +1,12 @@
+<p class="text-small text-grey-dk-100 mb-0">Copyright &copy; Espresso Aficionados</p>
+
+{% if page.mermaid %}
+  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <script>
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'default'
+    });
+    window.mermaid.init(undefined, document.querySelectorAll('.language-mermaid'));
+  </script>
+{% endif %}

--- a/info/info.md
+++ b/info/info.md
@@ -4,6 +4,15 @@ title: Information
 nav_order: 3
 has_children: true
 permalink: info
+mermaid: true
 ---
 
 # Useful Information
+
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```


### PR DESCRIPTION
This should allow to optionally include dynamically rendered Mermaid graphs on specific pages. Like this:

````markdown
---
layout: default
title: Information
nav_order: 3
has_children: true
permalink: info
mermaid: true # Manually enable Mermaid on a page to not unnecessarily use the Javascript everywhere
---

# Useful Information

```mermaid
graph TD;
    A-->B;
    A-->C;
    B-->D;
    C-->D;
```
````