### PR TITLE
Fix water.md sodium bicarb concentrate recipe

### DIFF
--- a/guides/water.md
+++ b/guides/water.md
@@ -138,7 +138,7 @@ Calcium Hydroxide | 7.40 | 1,000 | 10,000
 
 Compound | Mass (g) | Dilute volume (mL) | Concentration (mg/L of CaCO<sub>3</sub> equiv.)
 -------- | -------- | ------------------ | --------------------
-Sodium Bicarbonate | 16.79 | 1,000 | 10,000
+Sodium Bicarbonate | 8.39 | 1,000 | 10,000
 Potassium Bicarbonate | 20.00 | 1,000 | 10,000
 
 


### PR DESCRIPTION
I believe the baking soda (sodium bicarbonate) concentrate recipe on the water wiki is incorrect.
The water wiki provides [this recipe](https://espressoaf.com/guides/water.html#:~:text=CaCO3%2520equiv.%29-%2CSodium%2520Bicarbonate%2C10%252C000%2C-Potassium%2520Bicarbonate):
Compound | Mass (g) | Dilute volume (mL) | Concentration (mg/L of CaCO<sub>3</sub> equiv.)
-------- | -------- | ------------------ | --------------------
Sodium Bicarbonate | 16.79 | 1,000 | 10,000

My calculations show that should give a concentration of 20,000ppm by mass as CaCO3 (as opposed to the 10,000ppm claimed by the water wiki).

Therefore, I think the water wiki should be updated to:
Compound | Mass (g) | Dilute volume (mL) | Concentration (mg/L of CaCO<sub>3</sub> equiv.)
-------- | -------- | ------------------ | --------------------
Sodium Bicarbonate | 8.39 | 1,000 | 10,000

<br>
<br>

<details>
<summary>Working out the math if you want to see that</summary>

![image](https://github.com/user-attachments/assets/b030da8d-d093-43a6-9737-5519e00b29ac)
![image](https://github.com/user-attachments/assets/4bd56251-31e4-4b60-86f3-9c5125abb23c)

![image](https://github.com/user-attachments/assets/43dde4a7-6e10-47cc-8f8e-be1fabac2006)
![image](https://github.com/user-attachments/assets/cd0dc4c6-c6c4-4580-82e5-a4be79ae447f)

![image](https://github.com/user-attachments/assets/8cbb00e6-f17f-4ec9-80ec-72366712dd19)
![image](https://github.com/user-attachments/assets/05454c57-0f5e-4e32-9a0b-b5e407ec5b81)

![image](https://github.com/user-attachments/assets/1886ec4a-f2ae-43d1-bc8e-ea4f0c5181a4)
![image](https://github.com/user-attachments/assets/0316dcfd-6af3-452f-8ea3-51faa705ab0e)

![image](https://github.com/user-attachments/assets/ff6b1a35-659e-4790-ba85-2f003b168909)
![image](https://github.com/user-attachments/assets/5e01c81f-eef6-4313-8931-cfc7c0248319)

</details>

<details>
<summary>Sources for equation inputs</summary>
  
- Molar mass of calcium carbonate
  - [webqc.org](https://www.webqc.org/molecular-weight-of-CaCO3.html)
  - [PubChem](https://pubchem.ncbi.nlm.nih.gov/compound/Calcium-Carbonate#section=MeSH-Entry-Terms:~:text=Reference-,Molecular%20Weight,100.09%20g/mol,-Computed%20by%20PubChem)

- Molar mass of baking soda
  - [wikipedia](https://en.wikipedia.org/wiki/Sodium_bicarbonate#:~:text=Molar%20mass,mol%E2%88%921)
  - [webqc.org](https://www.webqc.org/molecular-weight-of-NaHCO3%28bakingsoda%29.html)
  - [PubChem](https://pubchem.ncbi.nlm.nih.gov/compound/Sodium-Bicarbonate#section=Depositor-Supplied-Synonyms:~:text=Reference-,Molecular%20Weight,84.007%20g/mol,-Computed%20by%20PubChem)

</details>