### PR TITLE
Gypsum recipe note

### DIFF
--- a/guides/water.md
+++ b/guides/water.md
@@ -130,9 +130,10 @@ Magnesium Sulphate Heptahydrate (Epsom Salt) | 24.63 | 1,000 | 10,000
 Magnesium Chloride Dihydrate | 13.11 | 1,000 | 10,000
 Magnesium Chloride Hexahydrate | 20.31 | 1,000 | 10,000
 Calcium Chloride Dihydrate | 14.69 | 1,000 | 10,000
-Calcium Sulphate Dihydrate (Gypsum) | 17.20 | 1,000 | 10,000
+Calcium Sulphate Dihydrate (Gypsum)* | 17.20 | 1,000 | 10,000
 Calcium Hydroxide | 7.40 | 1,000 | 10,000
 
+\* Note: Only around 3.6g of gypsum will fully dissolve in 1,000 mL of water at room temperature. This means the highest concentration, fully dissolved gypsum concenrate you can make is around 2,092 mg/L of CaCO<sub>3</sub> equiv. Even this weak of a concentrate is not recommended because gypsum gets even less soluble at brew temperatures. 0.86g of gypsum in 1,000 mL of water would make a safely dissolved solution with concentration of 500 mg/L of CaCO<sub>3</sub> equiv.
 
 ### KH (aka Carbonate Hardness aka Buffering capacity) Concentrates:
 

--- a/guides/water.md
+++ b/guides/water.md
@@ -133,7 +133,7 @@ Calcium Chloride Dihydrate | 14.69 | 1,000 | 10,000
 Calcium Sulphate Dihydrate (Gypsum)* | 17.20 | 1,000 | 10,000
 Calcium Hydroxide | 7.40 | 1,000 | 10,000
 
-\* Note: Only around 3.6g of gypsum will fully dissolve in 1,000 mL of water at room temperature. This means the highest concentration, fully dissolved gypsum concenrate you can make is around 2,092 mg/L of CaCO<sub>3</sub> equiv. Even this weak of a concentrate is not recommended because gypsum gets even less soluble at brew temperatures. 0.86g of gypsum in 1,000 mL of water would make a safely dissolved solution with concentration of 500 mg/L of CaCO<sub>3</sub> equiv.
+\* Note: Only around 3.6g of gypsum will fully dissolve in 1,000 mL of water at room temperature. This means the highest concentration, fully dissolved gypsum concenrate you can make is around 2,092 mg/L of CaCO<sub>3</sub> equiv. 1.72g of gypsum in 1,000 mL of water would make a safely dissolved solution with concentration of about 1000 mg/L of CaCO<sub>3</sub> equiv.
 
 ### KH (aka Carbonate Hardness aka Buffering capacity) Concentrates:
 


### PR DESCRIPTION
The water wiki provides a [gypsum concentrate recipe](https://espressoaf.com/guides/water.html#:~:text=Calcium%20Sulphate%20Dihydrate,10%2C000) that calls for 17.20g of gypsum in 1,000 mL of water. This would result in a concentration of around 10,000 ppm.
However, [gypsum has a room temperature solubility of only around 3.6g / L](https://www.sigmaaldrich.com/US/en/support/calculators-and-apps/solubility-table-compounds-water-temperature?srsltid=AfmBOoqquDNt2CZbVTddaE15sJOuv1VxLKaFlEx1jzyAoDB_iaAOzrDq#:~:text=0.176-,0.36,-0.2122).
This means that the provided recipe will not form a solution, but rather a mixture/slurry. This could make it difficult for users of the recipe to get consistent amounts of gypsum in the water made with that recipe. Additionally, it may make people wonder if they followed the recipe correctly.

I propose adding a note just below the relevant table to explain this.