### PR TITLE
Fixed formatting of Breville Pages

### DIFF
--- a/manufacturers/breville/General Breville Information.md
+++ b/manufacturers/breville/General Breville Information.md
@@ -1,11 +1,8 @@
-
 ---
-
 layout: default
 title: General Breville Information
 parent: Breville 
 grand_parent: Manufacturers
-
 ---
 
 

--- a/manufacturers/breville/The Bambino and Bambino Plus.md
+++ b/manufacturers/breville/The Bambino and Bambino Plus.md
@@ -1,11 +1,8 @@
-
 ---
-
 layout: default
 title: Bambini aka The Bambino and Bambino Plus
 parent: Breville 
 grand_parent: Manufacturers
-
 ---
 
 


### PR DESCRIPTION
Fixed formatting that likely is causing the pages to not show up in the correct location in the navigation and not rendering the headers correctly.