### PR TITLE
fix(z1): remove outdated FAQ link

### DIFF
--- a/manufacturers/zerno/z1.md
+++ b/manufacturers/zerno/z1.md
@@ -7,7 +7,7 @@ grand_parent: Manufacturers
 
 # Zerno Z1: Frequently Asked Questions
 
-- [Official FAQs](https://zerno.co/faq/) and [a new version](https://store.zerno.co/pages/faq)
+- [Official FAQs](https://zerno.co/faq/)
 - [User manual](https://store.zerno.co/pages/zerno-z1-manual)
 - [Zerno Coffee maintenance and usage videos](https://www.youtube.com/@zerno.grinder/videos)
 


### PR DESCRIPTION
The "old" FAQ was updated by Zerno. Both links point to the same FAQ now.

This PR removes an unnecessary link.